### PR TITLE
Declare notification name to be extern

### DIFF
--- a/system-apps/Terminal/TerminalWindow.h
+++ b/system-apps/Terminal/TerminalWindow.h
@@ -17,7 +17,7 @@
 #import <AppKit/NSWindowController.h>
 #import <AppKit/NSTabView.h>
 
-NSString *TerminalWindowNoMoreActiveWindowsNotification;
+extern NSString *TerminalWindowNoMoreActiveWindowsNotification;
 
 @interface TerminalWindowController : NSWindowController
 {


### PR DESCRIPTION
Fixes the build, because both main.m and TerminalWindow.m import this header.