### PR TITLE
* added the double click action

### DIFF
--- a/user-apps/LaternaMagica/AppController.h
+++ b/user-apps/LaternaMagica/AppController.h
@@ -85,6 +85,7 @@
 - (IBAction)rotateImage90:(id)sender;
 - (IBAction)rotateImage180:(id)sender;
 - (IBAction)rotateImage270:(id)sender;
+- (IBAction)doubleClicked:(id)sender;
 
 - (void)updateImageCount;
 

--- a/user-apps/LaternaMagica/AppController.m
+++ b/user-apps/LaternaMagica/AppController.m
@@ -93,6 +93,8 @@
 
     /* register the file view as drag destionation */
     [fileListView registerForDraggedTypes:[NSArray arrayWithObjects:NSFilenamesPboardType, nil]];
+    [fileListView setDoubleAction:@selector(doubleClicked:)];
+    [fileListView setTarget: self];
 
     /* add an observer for the file table view */
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_selectionDidChange:) name:NSTableViewSelectionDidChangeNotification object:fileListView];
@@ -498,6 +500,11 @@
   [self scaleView:destImage];
   [view setImage: destImage];
   [[view superview] setNeedsDisplay:YES];
+}
+
+- (IBAction)doubleClicked:(id)sender
+{
+  [smallWindow makeKeyAndOrderFront: self];
 }
 
 - (NSImage *)rotate: (NSImage *)image byAngle:(unsigned)angle


### PR DESCRIPTION
Useful if the ImageWindow is closed or covered by other windows. In the former case the only way to get it in front is to switch to 'full screen' and then back.